### PR TITLE
Fix Get-Branding URI Logic

### DIFF
--- a/vcd-h5-themes.psm1
+++ b/vcd-h5-themes.psm1
@@ -133,13 +133,10 @@ any prior release.
     if (($Tenant) -and ([Float]$apiVersion -lt 32)) {
         Write-Error("Get-Branding for a specified Tenant requires vCloud API v32 or later (vCloud Director 9.7), the detected API version is $apiVersion.")
         return
-    }
-
-    # For API path change in VCD 10.3+:
-    if ([Float]$apiVersion -lt 36.0) {
-        $uri = "https://$Server/cloudapi/branding"
+    } elseif ($Tenant) {
+        $uri = 'https://' + $Server + '/cloudapi/branding/tenant/' + $Tenant
     } else {
-        $uri = "https://$Server/cloudapi/branding/themes"
+        $uri = 'https://' + $Server + '/cloudapi/branding'
     }
     
     $mySessionID = Get-SessionId($Server)


### PR DESCRIPTION
Corrects URI construction logic in the Get-Branding command so that it
correctly contains the tenant if specified and removes incorrect logic
for if the API version is equal to or greater than 36.0

Resolves #12 