### PR TITLE
Add support for SVG Logos to Publish-Logo

### DIFF
--- a/vcd-h5-themes.psm1
+++ b/vcd-h5-themes.psm1
@@ -743,6 +743,11 @@ release.
          Return
     }
 
+    $LogoFileType = (Get-ChildItem -Path $LogoFile | Select-Object -ExpandProperty Extension) -replace "\.",""
+    if($LogoFileType -ieq "svg"){
+        $LogoFileType += "+xml"
+    }
+
     $headers = @{ "x-vcloud-authorization" = $mySessionID; "Accept" = "application/json;version=$apiVersion" }
 
     if ($Tenant) {
@@ -752,7 +757,7 @@ release.
     }
     
     try {
-        Invoke-WebRequest -Uri $uri -Headers $headers -Method Put -InFile $LogoFile -ContentType 'image/png' | Out-Null
+        Invoke-WebRequest -Uri $uri -Headers $headers -Method Put -InFile $LogoFile -ContentType "image/$LogoFileType" | Out-Null
     } catch {
         Write-Error ("Error occurred obtaining uploading logo file, Status Code is $($_.Exception.Response.StatusCode.Value__).")
         return


### PR DESCRIPTION
Updated the Publish-Logo to support SVG Logos as well as the previously
 previously hardcoded PNG files.

Resolves #14 